### PR TITLE
Handle ready state correctly

### DIFF
--- a/src/xhr-wrapper/index.js
+++ b/src/xhr-wrapper/index.js
@@ -5,11 +5,12 @@ export default function (request, onSuccess) {
   const { method = 'GET', url } = request;
 
   const xhr = new XMLHttpRequest();
-  xhr.open(method, url);
-
   xhr.onreadystatechange = function() {
     if (isSuccess(xhr)) {
       onSuccess(xhr)
     }
   };
+
+  xhr.open(method, url);
+  xhr.send();
 }


### PR DESCRIPTION
XHR readystate was not correctly tested; Leading to an empty responseText being given to the JSON API middleware
