### PR TITLE
Change external api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,14 @@ import _ from 'lodash';
 import createAPIActionCreator from './create-api-action-creator';
 import createJSONAPIActionCreator from './create-json-api-action-creator';
 
-export default {
-  createAPIActionCreators(configuration) {
-    const actionCreators = _.mapValues(configuration, createAPIActionCreator);
+export function createAPIActionCreators(configuration) {
+  const actionCreators = _.mapValues(configuration, createAPIActionCreator);
 
-    return actionCreators;
-  },
+  return actionCreators;
+};
 
-  createJSONAPIActionCreators(configuration) {
-    const actionCreators = _.mapValues(configuration, createJSONAPIActionCreator);
+export function createJSONAPIActionCreators(configuration) {
+  const actionCreators = _.mapValues(configuration, createJSONAPIActionCreator);
 
-    return actionCreators;
-  }
-}
+  return actionCreators;
+};

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -15,7 +15,7 @@ describe('External API', function () {
     return proxyquire('../index', {
       './create-api-action-creator': this.createAPIActionCreatorMock,
       './create-json-api-action-creator': this.createJSONAPIActionCreatorMock
-    }).default;
+    });
   };
 
   beforeEach(function () {


### PR DESCRIPTION
Let's update the way we import the library 
##### Before

``` js
import api from 'redux-api-action-creators';

api.createJSONAPIActionCreators
```
##### After

``` js
import { createJSONAPIActionCreators } from 'redux-api-action-creators';
```
